### PR TITLE
Create ValidSudoku.py

### DIFF
--- a/ValidSudoku.py
+++ b/ValidSudoku.py
@@ -1,0 +1,38 @@
+class TreeNode:
+    def __init__(self, val=0, left=None, right=None):
+        self.val = val
+        self.left = left
+        self.right = right
+
+class Codec:
+    def serialize(self, root):
+        def dfs(node):
+            if not node:
+                return "#"
+            return f"{node.val},{dfs(node.left)},{dfs(node.right)}"
+        
+        return dfs(root)
+
+    def deserialize(self, data):
+        def dfs(nodes):
+            val = next(nodes)
+            if val == "#":
+                return None
+            node = TreeNode(int(val))
+            node.left = dfs(nodes)
+            node.right = dfs(nodes)
+            return node
+
+        return dfs(iter(data.split(',')))
+
+# Example usage
+# Assuming TreeNode class is already defined
+root = TreeNode(1, TreeNode(2), TreeNode(3, TreeNode(4), TreeNode(5)))
+codec = Codec()
+data = codec.serialize(root)
+print(data)  # Serialized output
+root = codec.deserialize(data)
+# Reconstructing and verifying tree structure
+def inorder(node):
+    return inorder(node.left) + [node.val] + inorder(node.right) if node else []
+print(inorder(root))  # Output: [2, 1, 4, 3, 5]


### PR DESCRIPTION
Determine if a 9x9 Sudoku board is valid. Only the filled cells need to be validated according to the rules.

def is_valid_sudoku(board):
    def is_valid_unit(unit):
        unit = [i for i in unit if i != '.']
        return len(unit) == len(set(unit))
    
    for i in range(9):
        if not is_valid_unit(board[i]):  # Check rows
            return False
        if not is_valid_unit([board[j][i] for j in range(9)]):  # Check columns
            return False
    
    for i in range(0, 9, 3):
        for j in range(0, 9, 3):
            if not is_valid_unit([board[m][n] for m in range(i, i+3) for n in range(j, j+3)]):  # Check subgrids
                return False
    
    return True

# Example usage
board = [
    ["5","3",".",".","7",".",".",".","."],
    ["6",".",".","1","9","5",".",".","."],
    [".","9","8",".",".",".",".","6","."],
    ["8",".",".",".","6",".",".",".","3"],
    ["4",".",".","8",".","3",".",".","1"],
    ["7",".",".",".","2",".",".",".","6"],
    [".","6",".",".",".",".","2","8","."],
    [".",".",".","4","1","9",".",".","5"],
    [".",".",".",".","8",".",".","7","9"]
]
print(is_valid_sudoku(board))  # Output: True